### PR TITLE
Demo lack of CSS loading

### DIFF
--- a/app/posts/counter.module.css
+++ b/app/posts/counter.module.css
@@ -1,0 +1,5 @@
+.counter {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+}

--- a/app/posts/counter.tsx
+++ b/app/posts/counter.tsx
@@ -1,18 +1,21 @@
 import { useState } from "react";
+import styles from "./counter.module.css";
 
 export function Counter() {
   const [count, setCount] = useState(0);
 
   return (
-    <div className="flex flex-col items-center justify-center gap-4">
-      <h1 className="text-2xl">Counter</h1>
-      <p className="text-lg">Count: {count}</p>
-      <button
-        className="px-4 py-2 bg-blue-500 text-white rounded"
-        onClick={() => setCount(count + 1)}
-      >
-        Increment
-      </button>
+    <div className={styles.counter}>
+      <div className="flex flex-col items-center justify-center gap-4">
+        <h1 className="text-2xl">Counter</h1>
+        <p className="text-lg">Count: {count}</p>
+        <button
+          className="px-4 py-2 bg-blue-500 text-white rounded"
+          onClick={() => setCount(count + 1)}
+        >
+          Increment
+        </button>
+      </div>
     </div>
   );
 }

--- a/app/posts/counter.tsx
+++ b/app/posts/counter.tsx
@@ -5,17 +5,17 @@ export function Counter() {
   const [count, setCount] = useState(0);
 
   return (
-    <div className={styles.counter}>
-      <div className="flex flex-col items-center justify-center gap-4">
-        <h1 className="text-2xl">Counter</h1>
-        <p className="text-lg">Count: {count}</p>
-        <button
-          className="px-4 py-2 bg-blue-500 text-white rounded"
-          onClick={() => setCount(count + 1)}
-        >
-          Increment
-        </button>
-      </div>
+    <div
+      className={`flex flex-col items-center justify-center gap-4 ${styles.counter}`}
+    >
+      <h1 className="text-2xl">Counter</h1>
+      <p className="text-lg">Count: {count}</p>
+      <button
+        className="px-4 py-2 bg-blue-500 text-white rounded"
+        onClick={() => setCount(count + 1)}
+      >
+        Increment
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
In this case, the styles for `counter.module.css` are not present in the server render, causing the counter to layout-shift.